### PR TITLE
Fix panic when processing untyped nil values in maps

### DIFF
--- a/initialize_test.go
+++ b/initialize_test.go
@@ -345,3 +345,291 @@ func TestCyclic(t *testing.T) {
 		_ = niltoempty.Initialize(&v)
 	})
 }
+
+// New structs for testing based on RagNamedQuerySuccessEvent and QueryResult
+type MockQueryResultForTest struct {
+	ID            string                   `json:"id"`
+	RenderedQuery map[string]interface{}   `json:"rendered_query"` // Can be nil, or contain nil interface values
+	Results       []map[string]interface{} `json:"results"`        // Can be nil
+	SimpleSlice   []int                    `json:"simple_slice"`   // Can be nil
+	SimpleMap     map[string]string        `json:"simple_map"`     // Can be nil
+	Payload       interface{}              `json:"payload"`        // Can be untyped nil, or typed nil (e.g. (*SomeStruct)(nil) or (map[string]int)(nil))
+	NestedStruct  *NestedStructForTest     `json:"nested_struct"`  // Pointer to a struct, can be nil or struct can have nil fields
+}
+
+type NestedStructForTest struct {
+	Name           string       `json:"name"`
+	DataSlice      []string     `json:"data_slice"` // Can be nil
+	DataMap        map[int]bool `json:"data_map"`   // Can be nil
+	InterfaceField interface{}  `json:"interface_field"`
+}
+
+type MockEventWithPtrSliceForTest struct {
+	EventName string                    `json:"event_name"`
+	Items     []*MockQueryResultForTest `json:"items"` // Slice of pointers, key for the reported bug
+}
+
+func TestSliceOfPointersToStructsWithProblematicFields(t *testing.T) {
+	t.Run("struct with nil map/slice/typed-nil-interface fields pointed to by slice element", func(t *testing.T) {
+		event := MockEventWithPtrSliceForTest{
+			EventName: "TestEvent1",
+			Items: []*MockQueryResultForTest{
+				{ // Non-nil pointer to MockQueryResultForTest
+					ID:            "qr1",
+					RenderedQuery: nil,                   // Expected: {}
+					Results:       nil,                   // Expected: []
+					SimpleSlice:   nil,                   // Expected: []
+					SimpleMap:     nil,                   // Expected: {}
+					Payload:       (map[string]int)(nil), // Typed nil map, Expected: {}
+					NestedStruct: &NestedStructForTest{
+						Name:           "nested1",
+						DataSlice:      nil,             // Expected: []
+						DataMap:        nil,             // Expected: {}
+						InterfaceField: ([]string)(nil), // Typed nil slice, Expected: []
+					},
+				},
+			},
+		}
+
+		originalItemPtr := event.Items[0]
+		originalNestedStructPtr := event.Items[0].NestedStruct
+
+		niltoempty.Initialize(&event)
+
+		require.NotNil(t, event.Items)
+		require.Len(t, event.Items, 1)
+		require.NotNil(t, event.Items[0])
+
+		assert.Same(t, originalItemPtr, event.Items[0], "Pointer to MockQueryResultForTest should be preserved")
+
+		item0 := event.Items[0]
+		assert.NotNil(t, item0.RenderedQuery, "RenderedQuery should be initialized")
+		assert.Empty(t, item0.RenderedQuery, "RenderedQuery should be empty map")
+		assert.NotNil(t, item0.Results, "Results should be initialized")
+		assert.Empty(t, item0.Results, "Results should be empty slice")
+		assert.NotNil(t, item0.SimpleSlice, "SimpleSlice should be initialized")
+		assert.Empty(t, item0.SimpleSlice, "SimpleSlice should be empty slice")
+		assert.NotNil(t, item0.SimpleMap, "SimpleMap should be initialized")
+		assert.Empty(t, item0.SimpleMap, "SimpleMap should be empty map")
+
+		require.NotNil(t, item0.Payload, "Payload (typed nil map) should be initialized")
+		payloadMap, ok := item0.Payload.(map[string]int)
+		require.True(t, ok, "Payload should be a map[string]int, got %T", item0.Payload)
+		assert.Empty(t, payloadMap, "Payload (typed nil map) should be an empty map")
+
+		require.NotNil(t, item0.NestedStruct)
+		assert.Same(t, originalNestedStructPtr, item0.NestedStruct, "Pointer to NestedStructForTest should be preserved")
+		assert.NotNil(t, item0.NestedStruct.DataSlice)
+		assert.Empty(t, item0.NestedStruct.DataSlice)
+		assert.NotNil(t, item0.NestedStruct.DataMap)
+		assert.Empty(t, item0.NestedStruct.DataMap)
+
+		require.NotNil(t, item0.NestedStruct.InterfaceField, "NestedStruct.InterfaceField (typed nil slice) should be initialized")
+		interfaceSlice, okSlice := item0.NestedStruct.InterfaceField.([]string)
+		require.True(t, okSlice, "NestedStruct.InterfaceField should be a []string, got %T", item0.NestedStruct.InterfaceField)
+		assert.Empty(t, interfaceSlice, "NestedStruct.InterfaceField (typed nil slice) should be an empty slice")
+	})
+
+	t.Run("struct with untyped nil interface field", func(t *testing.T) {
+		event := MockEventWithPtrSliceForTest{
+			EventName: "TestEvent2",
+			Items: []*MockQueryResultForTest{
+				{
+					ID:      "qr2",
+					Payload: nil, // Untyped nil
+					NestedStruct: &NestedStructForTest{
+						Name:           "nested2",
+						InterfaceField: nil, // Untyped nil
+					},
+				},
+			},
+		}
+		niltoempty.Initialize(&event)
+		require.NotNil(t, event.Items)
+		require.Len(t, event.Items, 1)
+		item0 := event.Items[0]
+		assert.Nil(t, item0.Payload, "Untyped nil Payload should remain nil")
+		require.NotNil(t, item0.NestedStruct)
+		assert.Nil(t, item0.NestedStruct.InterfaceField, "Untyped nil NestedStruct.InterfaceField should remain nil")
+	})
+
+	t.Run("slice of pointers containing a nil pointer", func(t *testing.T) {
+		event := MockEventWithPtrSliceForTest{
+			EventName: "TestEvent3",
+			Items: []*MockQueryResultForTest{
+				nil, // A nil pointer in the slice
+				{ID: "qr3-valid", SimpleSlice: nil},
+			},
+		}
+		niltoempty.Initialize(&event)
+		require.NotNil(t, event.Items)
+		require.Len(t, event.Items, 2)
+		assert.Nil(t, event.Items[0], "Nil pointer in slice should remain nil")
+		require.NotNil(t, event.Items[1])
+		assert.NotNil(t, event.Items[1].SimpleSlice, "SimpleSlice in non-nil element should be initialized")
+		assert.Empty(t, event.Items[1].SimpleSlice)
+	})
+
+	t.Run("map with interface value being untyped nil (potential panic point)", func(t *testing.T) {
+		event := MockEventWithPtrSliceForTest{
+			EventName: "TestEvent4",
+			Items: []*MockQueryResultForTest{
+				{
+					ID: "qr4",
+					RenderedQuery: map[string]interface{}{
+						"key1": "value1",
+						"key2": nil,                   // Untyped nil interface as map value
+						"key3": (map[string]int)(nil), // typed nil map as interface value
+					},
+				},
+			},
+		}
+
+		// This subtest previously panicked. Now, untyped nils in map values are preserved.
+		// Typed nils (like map[string]int)(nil) are still initialized.
+		niltoempty.Initialize(&event)
+
+		// If the code does not panic (e.g., after a fix), these assertions should hold:
+		require.NotNil(t, event.Items)
+		require.Len(t, event.Items, 1)
+		item0 := event.Items[0]
+		require.NotNil(t, item0.RenderedQuery)
+		assert.Equal(t, "value1", item0.RenderedQuery["key1"])
+		assert.Nil(t, item0.RenderedQuery["key2"], "Untyped nil interface map value should remain nil")
+
+		require.NotNil(t, item0.RenderedQuery["key3"], "Typed nil map in interface map value should be initialized")
+		key3Map, ok := item0.RenderedQuery["key3"].(map[string]int)
+		require.True(t, ok, "item0.RenderedQuery[\"key3\"] expected to be map[string]int, got %T", item0.RenderedQuery["key3"])
+		assert.Empty(t, key3Map)
+	})
+
+	t.Run("empty slice of pointers", func(t *testing.T) {
+		event := MockEventWithPtrSliceForTest{
+			EventName: "TestEvent5",
+			Items:     []*MockQueryResultForTest{}, // Empty slice
+		}
+		niltoempty.Initialize(&event)
+		require.NotNil(t, event.Items, "Empty slice of pointers should remain not-nil (empty)")
+		assert.Empty(t, event.Items, "Empty slice of pointers should remain empty")
+	})
+
+	t.Run("nil slice of pointers", func(t *testing.T) {
+		event := MockEventWithPtrSliceForTest{
+			EventName: "TestEvent6",
+			Items:     nil, // Nil slice
+		}
+		niltoempty.Initialize(&event)
+		require.NotNil(t, event.Items, "Nil slice of pointers should be initialized to empty slice")
+		assert.Empty(t, event.Items, "Nil slice of pointers should be initialized to empty")
+	})
+
+	t.Run("nested struct pointer being nil", func(t *testing.T) {
+		event := MockEventWithPtrSliceForTest{
+			EventName: "TestEvent7",
+			Items: []*MockQueryResultForTest{
+				{
+					ID:           "qr7",
+					NestedStruct: nil, // Nil pointer to nested struct
+				},
+			},
+		}
+		niltoempty.Initialize(&event)
+		require.NotNil(t, event.Items)
+		require.Len(t, event.Items, 1)
+		item0 := event.Items[0]
+		assert.Nil(t, item0.NestedStruct, "Nil NestedStruct pointer should remain nil")
+	})
+}
+
+// Additional edge case tests requested by user
+func TestAdditionalEdgeCasesForNilToEmpty(t *testing.T) {
+
+	// 1. Metadata map containing an untyped nil value should no longer panic; nil value is preserved.
+	t.Run("metadata with untyped nil value is preserved", func(t *testing.T) {
+		t.Parallel()
+		type EventWithMetadata struct {
+			Metadata map[string]interface{} `json:"metadata"`
+		}
+
+		event := EventWithMetadata{
+			Metadata: map[string]interface{}{
+				"foo": nil, // untyped nil interface{}
+			},
+		}
+
+		// Should NOT panic anymore. Value should remain as-is (nil entry preserved).
+		assert.NotPanics(t, func() {
+			niltoempty.Initialize(&event)
+		}, "Initialize should no longer panic when map contains untyped nil value")
+
+		// Ensure map is still present and the value remains nil.
+		require.NotNil(t, event.Metadata)
+		val, exists := event.Metadata["foo"]
+		assert.True(t, exists, "key foo should still exist in metadata map")
+		assert.Nil(t, val, "value of key foo should remain nil")
+	})
+
+	// 2. Map containing a typed nil pointer should NOT panic, pointer should stay nil
+	t.Run("map with typed nil pointer value stays nil", func(t *testing.T) {
+		t.Parallel()
+		type PayloadStruct struct {
+			Name string `json:"name"`
+		}
+
+		type EventWithAdditionalFields struct {
+			AdditionalFields map[string]interface{} `json:"additional_fields"`
+		}
+
+		var typedNilPointer *PayloadStruct = nil
+		event := EventWithAdditionalFields{
+			AdditionalFields: map[string]interface{}{
+				"payload": typedNilPointer, // typed nil pointer
+			},
+		}
+
+		// Should NOT panic
+		niltoempty.Initialize(&event)
+
+		// The pointer should still be nil after initialization
+		require.NotNil(t, event.AdditionalFields)
+		payload, ok := event.AdditionalFields["payload"].(*PayloadStruct)
+		assert.True(t, ok, "payload should remain of type *PayloadStruct, got %T", event.AdditionalFields["payload"])
+		assert.Nil(t, payload, "typed nil pointer value should remain nil after Initialize")
+	})
+
+	// 3. Slice containing an untyped nil interface value should not panic and nil should stay nil
+	t.Run("slice of interfaces containing untyped nil", func(t *testing.T) {
+		t.Parallel()
+		type StructWithInterfaceSlice struct {
+			Items []interface{} `json:"items"`
+		}
+
+		event := StructWithInterfaceSlice{
+			Items: []interface{}{nil, "foo", map[string]interface{}{"bar": 1}},
+		}
+
+		// Should NOT panic
+		niltoempty.Initialize(&event)
+
+		require.Len(t, event.Items, 3)
+		assert.Nil(t, event.Items[0], "first element should remain nil")
+	})
+
+	// 4. Self-referential map through interface{} value – current implementation would recurse forever.
+	//    We include the test but skip it until the algorithm is made cycle-safe for interfaces.
+	t.Run("self-referential map via interface cycle", func(t *testing.T) {
+		// Mark skipped for now to avoid infinite recursion in the current implementation.
+		t.Skip("skipping until initializeNils handles cycles through interface values safely")
+
+		type StructWithCyclicMap struct {
+			Data map[string]interface{} `json:"data"`
+		}
+
+		cyclic := make(map[string]interface{})
+		cyclic["self"] = cyclic // cycle via interface{}
+		event := StructWithCyclicMap{Data: cyclic}
+
+		// If/when initializeNils is fixed, this should not panic and should terminate.
+		niltoempty.Initialize(&event)
+	})
+}


### PR DESCRIPTION
This PR fixes an issue where the library would panic when encountering untyped 
nil values in maps with interface{} values.

## Problem

* When processing maps with interface{} values containing untyped nil, 
  the reflect.Value for that nil is invalid
* Calling methods like .Kind(), .Type() or .Interface() on invalid reflect.Values 
  causes a panic
* This occurred particularly when maps contained interface{} values set to nil

## Solution

* Add early validation checks to ensure reflect.Value is valid before processing
* Skip invalid values in maps rather than attempting to initialize them
* Preserve untyped nil values in maps (they remain nil)
* Continue initializing typed nil values (like `(map[string]int)(nil)`) as empty 
  collections

## Testing

* Added comprehensive tests covering various edge cases:
  * Maps with untyped nil interface{} values
  * Maps with typed nil values (pointers, maps, slices)
  * Slice of interfaces containing untyped nil
  * Nested structures with nil fields
  * Complex scenarios mixing different nil types